### PR TITLE
tidb: add strict-format in lightning config to speedup load data

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ The following table shows data ingestion performance for the complete dataset (3
 | ClickHouse    | 🟢 57.00 sec  | 694,723   | ✅ Success | Native CSV, columnar |
 | Doris         | 🟢 85.00 sec  | 447,940   | ✅ Success | Stream Load, BE warmup  |
 | StarRocks     | 🟢 100.00 sec | 379,777   | ✅ Success | Vectorized ingest    |
-| TiDB/TiFlash  | 🔴 735.00 sec | 51,563    | ✅ Success | Lightning, replica   |
+| TiDB/TiFlash  | 🟡 160.00 sec | 238,026   | ✅ Success | Lightning, replica   |
 | ColumnStore   | 🟢 39.00 sec  | 1,109,264 | ✅ Success | cpimport, conversion |
 
 ### Query Execution Performance

--- a/load/tidb-lightning.toml
+++ b/load/tidb-lightning.toml
@@ -15,11 +15,12 @@ sorted-kv-dir = "/tmp/tidb_sort"
 data-source-dir = "./csv"
 batch-import-ratio = 1.2
 read-block-size = 4194304
+strict-format = true
 
 [mydumper.csv]
 separator = ','
 delimiter = '"'
-terminator = ''
+terminator = "\n"
 header = false
 not-null = false
 null = '\N'


### PR DESCRIPTION
Because `bts.flights.csv` is a large 6GB CSV file, Lightning doesn't split it and perform multi-threaded reading by default. Users need to enable `strict-format` for concurrent reading. After enabling it, the actual import time improved to 160 seconds in testing.
see https://docs.pingcap.com/tidb/stable/tidb-lightning-configuration/#strict-format for more details.
![img_v3_02rn_aeae5212-7ce3-4cf8-abd4-d30ec0e8c42g](https://github.com/user-attachments/assets/59b8fc9f-2c79-4e00-8c22-ec4f193f235e)

Furthermore, we found that the ecode decimal process is slow and we are optimizing it. 
<img width="3834" height="930" alt="7ec3b76f-b130-48ab-a0d2-c5c8e89ff87c" src="https://github.com/user-attachments/assets/1bc4149d-fd10-4e9e-9b0e-40af04972c8e" />
After the https://github.com/pingcap/tidb/pull/64271 merged, the speed will be improved to 90s final.
![img_v3_02rn_27e68ea3-c80c-468f-80bf-40907776049g](https://github.com/user-attachments/assets/93aa62fd-660a-4bcd-b15b-193fd31e7d57)

