### PR TITLE
tidb: set global `tidb_analyze_column_options` to 'all' in load script

### DIFF
--- a/load/load_data.py
+++ b/load/load_data.py
@@ -408,6 +408,9 @@ class TiDBLoader(DatabaseLoader):
         self.logger.info("Creating TiDB database and tables...")
         
         sql_commands = [
+            # Set analyze options for better statistics collection for OLAP workloads
+            # Ref: https://docs.pingcap.com/tidb/stable/system-variables/#tidb_analyze_column_options-new-in-v830
+            f"SET GLOBAL tidb_analyze_column_options = 'all'",
             f"DROP DATABASE IF EXISTS `{self.config.database}`",
             f"CREATE DATABASE `{self.config.database}`",
             f"USE `{self.config.database}`",


### PR DESCRIPTION
Set analyze options for better statistics collection for OLAP workloads.
Ref: https://github.com/toddstoffel/analytics_benchmark/issues/4#issuecomment-3495325973

Note that after data is imported via TiDB Lightning, an ANALYZE TABLE operation will be triggered. Previously, the default `tidb_analyze_column_options` was PREDICATE, so it ran very quickly. With this change to ALL, it will take longer to complete. Therefore, this modification will not only improve query performance but also increase the total data load time.